### PR TITLE
Fix default DEFAULT_SERVER_URL

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,5 @@
 VAGRANTFILE_API_VERSION = "2"
+
 Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/trusty64"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 VAGRANTFILE_API_VERSION = "2"
-
+Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/trusty64"
 


### PR DESCRIPTION
vagrant up fail. 
ref: https://github.com/hashicorp/vagrant/issues/9442
```
➜  dev-vagrant git:(master) vagrant box add ubuntu/trusty64
The box 'ubuntu/trusty64' could not be found or
could not be accessed in the remote catalog. If this is a private
box on HashiCorp's Atlas, please verify you're logged in via
`vagrant login`. Also, please double-check the name. The expanded
URL and error message are shown below:

URL: ["https://atlas.hashicorp.com/ubuntu/trusty64"]
```
